### PR TITLE
creating snippet to force cache lifespan functionality

### DIFF
--- a/wp-rocket/cache/wp-rocket-force-cache-lifespan.php
+++ b/wp-rocket/cache/wp-rocket-force-cache-lifespan.php
@@ -1,0 +1,20 @@
+<?php
+
+// Add the snippet below to either functions.php file or via a code snippet plugin and refresh any WP Admin page to run it
+// Will delete any cache files older than the time passed to purge_expired_files() - 30 seconds is set below by default
+add_action( 'admin_init', function() {
+	$faux_cache_lifespan_obj = new WP_Rocket\Engine\Cache\PurgeExpired\PurgeExpiredCache( WP_ROCKET_CACHE_PATH );
+	$faux_cache_lifespan_obj->purge_expired_files( 30 ); // Pass custom Cache Lifespan time in seconds
+} );
+
+// This is not necessary, but will create log of pages cleared in the WP root directory
+add_action( 'rocket_after_automatic_cache_purge_dir', function( $url_deleted, $args ) {
+	// Added by WP Rocket Support
+	error_log( "_______"
+	. "LOG"
+	. "_______\n"
+	. "TIME: " . date("Y-m-d H:i:s", $_SERVER["REQUEST_TIME"] ) . "\n"
+	. "URL_DELETED: " . print_r( $url_deleted, true ) . "\n\n"
+	. "ARGS: " . print_r( $args, true ) . "\n\n"
+	, 3, ABSPATH . "/cache-lifespan-purged-pages.log" );
+}, 9999, 2 );


### PR DESCRIPTION
When debugging issues related to Cache Lifespan, it can be time consuming to wait for the Cache Lifespan to run (can only set to 1 hour minimum in WPR settings).

This snippet allows us to run the Cache Lifespan setting while submitting a very short timespan setting in seconds, allowing for much quicker troubleshooting.