### PR TITLE
Removed error logging line

### DIFF
--- a/wp-rocket/wp-rocket-oci-clear-related.php
+++ b/wp-rocket/wp-rocket-oci-clear-related.php
@@ -18,9 +18,6 @@ defined('ABSPATH') or die();
 function wpr_clear_oci( $the_post ) {
 	
 	$the_post = rtrim($the_post,"/");
-	 
-	 error_log("\n Post: " . print_r($the_post, true), 3, ABSPATH . "/wp-content/wpr-logs/oci.txt");
-
 
 	global $wpdb;
     $wpdb->delete($wpdb->prefix."wpr_above_the_fold", array( 'url' => $the_post ));


### PR DESCRIPTION
# Description

Small update to [wp-rocket-oci-clear-related.php](https://github.com/wp-media/wp-rocket-snippets/blob/main/wp-rocket/wp-rocket-oci-clear-related.php)

Remove the Error logging line:

`error_log("\n Post: " . print_r($the_post, true), 3, ABSPATH . "/wp-content/wpr-logs/oci.txt");`

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
