### PR TITLE
Code snippet to allow caching for Taxonomies excluded from cache and optimization by cache rules

### DIFF
--- a/wp-rocket/wp-rocket-exclude-taxonomies-from-cache-rules.php
+++ b/wp-rocket/wp-rocket-exclude-taxonomies-from-cache-rules.php
@@ -1,0 +1,27 @@
+<?php
+// This code snippet modifies caching and optimization rules for taxonomies that are not cached by default.
+add_action( 'wp_rocket_loaded', function() {
+    $container = apply_filters( 'rocket_container', null );
+
+    if ( ! $container ) {
+        return;
+    }
+
+    // Get the actual instance of TaxonomySubscriber
+    $taxonomy_subscriber = $container->get( 'taxonomy_subscriber' );
+
+    if ( ! $taxonomy_subscriber ) {
+        return;
+    }
+
+    // Get subscribed events (for debugging)
+    $subscribed_events = $taxonomy_subscriber->get_subscribed_events();
+
+    // Remove filter from 'rocket_buffer'
+    remove_filter( 'rocket_buffer', [ $taxonomy_subscriber, 'stop_optimizations_for_not_valid_taxonomy_pages' ], 1 );
+
+    // Remove action from 'do_rocket_generate_caching_files'
+    remove_action( 'do_rocket_generate_caching_files', [ $taxonomy_subscriber, 'disable_cache_on_not_valid_taxonomy_pages' ] );
+
+
+}, PHP_INT_MAX );


### PR DESCRIPTION
# Description
This is a new code snippet that modifies caching and optimization rules for taxonomies that are not cached by default.

When a customer uses rewrite rules to modify their URLs, this sometimes can result in them having the term URL not the same as the current URL.

When this happens (when the URL is not the same), based on the checks we are doing in [is_not_valid_taxonomy_page()](https://github.com/wp-media/wp-rocket/blob/8492f66c4a1895867f6ab30881210f64c8011d42/inc/Engine/Cache/TaxonomySubscriber.php#L50), the rewritten URL ends up not getting cached and optimized.

This is coming from the change that was made in [GitHub Issue 7106](https://github.com/wp-media/wp-rocket/issues/7106) and https://github.com/wp-media/wp-rocket.me/issues/4164

Fixes #(4164)
*Explain how this code impacts users.*
This code will allow users to be able to override the default caching rules in [is_not_valid_taxonomy_page()](https://github.com/wp-media/wp-rocket/blob/8492f66c4a1895867f6ab30881210f64c8011d42/inc/Engine/Cache/TaxonomySubscriber.php#L50) by unhooking the `disable_cache_on_not_valid_taxonomy_pages` and `stop_optimizations_for_not_valid_taxonomy_pages` from `do_rocket_generate_caching_files` and `rocket_buffer`

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario
- Have a rewritten URL to change for example https://suzan.wpr-support.com/ingredient/maggi/, to https://suzan.wpr-support.com/steenstrips/maggi/
- Since these two are not the same, WP Rocket will not cache the rewritten URL.

Here is an example of the Rewrite rule:

```
function method_one_rewrite_rule() {
$taxonomy = 'ingredient';
add_rewrite_rule(
    '^steenstrips/([^/]+)/?$',         
    sprintf( 'index.php?%s=$matches[1]', $taxonomy),  
    'top'                                      
);
}
add_action( 'init', 'method_one_rewrite_rule' );
```
- HS Ticket: https://secure.helpscout.net/conversation/2832222833/537596

## Technical description

### Documentation

- This code is unhooking the actions to allow cache and optimization for taxonomies

### New dependencies

No

### Risks

- While this snippet will unhook those filters and get things working, this approach of removing those filters has a risk of caching and preloading non-existent taxonomies, which could result in bloating the cache database.

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
